### PR TITLE
Fix JSON destroy response and route typo

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -14,7 +14,7 @@ class BooksController < ApplicationController
     @book.destroy
     respond_to do |format|
       format.html { redirect_to '/' }
-      format.json { haed :no_content }
+      format.json { head :no_content }
     end
   end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -6,7 +6,7 @@ class Book < ApplicationRecord
   }
 
   scope :costly, -> { where("price > ?", 3000) }
-  scope :written_about, -> (theme) { where("name like ?", "%#{theme}") }
+  scope :written_about, -> (theme) { where("name like ?", "%#{theme}%") }
 
   belongs_to :publisher
   has_many :book_authors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get '/books/:id' => 'books#show'
-  delete '/books/;id' => 'books#destroy'
+  delete '/books/:id' => 'books#destroy'
   resources :publishers
   resource :profile, only: %i{show edit update}
 end


### PR DESCRIPTION
## Summary
- fix `haed` typo in BooksController JSON response
- fix `written_about` scope to match anywhere in book name
- correct `/books/:id` route path

## Testing
- `bundle exec rake test` *(fails: rbenv: version `3.0.0` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840475823d88328ae5473e9cb830dcd